### PR TITLE
Add licence info to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setuptools.setup(
     version="8.1.0",
     author="Priit Paluoja",
     author_email="priit.paluoja@gmail.com",
+    license="MIT",
     description="Thonny plugin for lahendus.ut.ee",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
It looks like PyPI, wheel or something else has changed how to present missing metadata fields in the PyPI Json API:

* https://pypi.org/pypi/thonny-lahendus/7.0.0/json shows "licence":""
* https://pypi.org/pypi/thonny-lahendus/8.1.0/json shows "license": null 

Unfortunately Thonny currently does not check for null-s and gets an error when trying to display null licence in its pip GUI.

This PR should fix the situation for this package.